### PR TITLE
Fix _collectionPath and _schema returning undefined

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -105,11 +105,24 @@ class Model {
    * Collection Path.
    *
    * @readonly
+   * @static
+   * @type {Schema}
+   * @memberof Model
+   */
+  static get _schema() {    
+    return this.schema();
+  }
+
+  /**
+   * Collection Path.
+   *
+   * @readonly
+   * @static
    * @type {String}
    * @memberof Model
    */
-  get _collectionPath() {
-    return this.constructor._collectionPath
+  static get _collectionPath() {    
+    return this.collectionPath();
   }
 
   /**


### PR DESCRIPTION
With the following model I was getting an error using your package.

```
// venueModel.ts
const { Model, schema, field } = require('firestore-schema-validator')
 
const venueSchema = schema({
  name: field('Name')
    .string()
    .trim(),
})
 
class Venue extends Model {
  // Path to Cloud Firestore collection.
  static collectionPath() {
    return 'tests';
  }
 
  // Model Schema.
  static schema() {
    return venueSchema;
  }
}

export default Venue;

// createVenueRoute
const venue = await Venue.create({
  name: 'Test venue',
});

console.log(venue);
```

`Value for argument \"collectionPath\" is not a valid resource path. Path must be a non-empty string.`

It wasn't able to get the collectionPath value. To get it to work I had to make the _collectionPath method static and also add a _schema method. Not sure if this was an issue with my implementation of the package or the package itself so feel free to ignore this PR if I'm wrong.